### PR TITLE
fix: use default address map as fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,11 +244,6 @@ class AmazonAdsFormatter {
       .replace(/[^a-z0-9]/g, "")
       .trim().substring(0, postal.length - 4);
 
-    if (formatted.length > 5) {
-      // remove the last 4 characters
-      formatted = formatted.slice(0, 5);
-    }
-
     return formatted;
   }
 

--- a/index.js
+++ b/index.js
@@ -120,7 +120,9 @@ class AmazonAdsFormatter {
 
     const countryCode =
       this.maps.countryMap[country.toLowerCase()] || country.toLowerCase();
-    const addressMap = this.maps.addressMappings[countryCode] || this.maps.addressMappings.default;
+    const addressMap =
+      this.maps.addressMappings[countryCode] ||
+      this.maps.addressMappings.default;
 
     // Apply special character mappings
     Object.entries(this.maps.specialCharacterMap).forEach(
@@ -242,13 +244,12 @@ class AmazonAdsFormatter {
     let formatted = postal
       .toLowerCase()
       .replace(/[^a-z0-9]/g, "")
-      .trim().substring(0, postal.length - 4);
-
+      .trim();
+    formatted = formatted.substring(0, formatted.length - 4);
     return formatted;
   }
 
   formatRecord(record) {
-
     if (!record) return {};
 
     if (typeof record !== "object") {

--- a/index.js
+++ b/index.js
@@ -244,7 +244,6 @@ class AmazonAdsFormatter {
       .replace(/[^a-z0-9]/g, "")
       .trim().substring(0, postal.length - 4);
 
-    formatted = formatted.replace(/[^a-z0-9]/g, "").trim();
     if (formatted.length > 5) {
       // remove the last 4 characters
       formatted = formatted.slice(0, 5);

--- a/index.js
+++ b/index.js
@@ -116,13 +116,11 @@ class AmazonAdsFormatter {
   formatAddress(address, country = "us") {
     if (!address) return "";
 
-    let formatted = address.toLowerCase();
+    let formatted = address.toLowerCase().trim();
 
     const countryCode =
       this.maps.countryMap[country.toLowerCase()] || country.toLowerCase();
-    const addressMap = this.maps.addressMappings[countryCode];
-
-    const defaultAddressmap = this.maps.addressMappings.default;
+    const addressMap = this.maps.addressMappings[countryCode] || this.maps.addressMappings.default;
 
     // Apply special character mappings
     Object.entries(this.maps.specialCharacterMap).forEach(
@@ -161,14 +159,6 @@ class AmazonAdsFormatter {
 
     // Apply country-specific address mappings
     Object.entries(addressMap).forEach(([word, replacement]) => {
-      formatted = formatted.replace(
-        new RegExp(`\\b${word}\\b`, "g"),
-        replacement
-      );
-    });
-
-    // Apply default address mappings
-    Object.entries(defaultAddressmap).forEach(([word, replacement]) => {
       formatted = formatted.replace(
         new RegExp(`\\b${word}\\b`, "g"),
         replacement
@@ -252,7 +242,7 @@ class AmazonAdsFormatter {
     let formatted = postal
       .toLowerCase()
       .replace(/[^a-z0-9]/g, "")
-      .trim();
+      .trim().substring(0, postal.length - 4);
 
     formatted = formatted.replace(/[^a-z0-9]/g, "").trim();
     if (formatted.length > 5) {

--- a/index.test.js
+++ b/index.test.js
@@ -79,8 +79,8 @@ describe("AmazonAdsFormatter", () => {
 
   describe("formatPostal", () => {
     it("should format postal codes correctly", () => {
-      expect(formatter.formatPostal("12345-6789")).toBe("12345");
-      expect(formatter.formatPostal("K1A 0B1")).toBe("k1a0b");
+        expect(formatter.formatPostal("12345-6789")).toBe("12345");
+      expect(formatter.formatPostal("K1A 0B1")).toBe("k1");
     });
   });
 

--- a/index.test.js
+++ b/index.test.js
@@ -79,8 +79,9 @@ describe("AmazonAdsFormatter", () => {
 
   describe("formatPostal", () => {
     it("should format postal codes correctly", () => {
-        expect(formatter.formatPostal("12345-6789")).toBe("12345");
+      expect(formatter.formatPostal("12345-6789")).toBe("12345");
       expect(formatter.formatPostal("K1A 0B1")).toBe("k1");
+      expect(formatter.formatPostal("K1A")).toBe("");
     });
   });
 


### PR DESCRIPTION
Fixing the address formatting with using default mapping only in case of when there is o mapping available for a country and fix the postal code formatting to drop the last 4 digits of the postal code